### PR TITLE
(QA) fix PVS reports

### DIFF
--- a/binary_bakery_lib/content_meta.cpp
+++ b/binary_bakery_lib/content_meta.cpp
@@ -59,8 +59,8 @@ namespace
 auto bb::get_header_bytes(
     const content_meta& meta,
     const compression_mode compression,
-   const byte_count uncompressed_size,
-   const byte_count compressed_size
+   const byte_count& uncompressed_size,
+   const byte_count& compressed_size
 ) -> std::array<uint8_t, 16>
 {
    header head;

--- a/binary_bakery_lib/content_meta.h
+++ b/binary_bakery_lib/content_meta.h
@@ -21,8 +21,8 @@ namespace bb {
    [[nodiscard]] auto get_header_bytes(
        const content_meta& meta,
        const compression_mode compression,
-      const byte_count uncompressed_size,
-      const byte_count compressed_size
+      const byte_count& uncompressed_size,
+      const byte_count& compressed_size
    ) -> std::array<uint8_t, 16>;
 
 }


### PR DESCRIPTION
as reported by [PVS Studio](https://pvs-studio.com/en/) (a static code analyzer tool I use for some other projects too):  
- V801 Decreased performance. It is better to redefine the third function argument as a reference. Consider replacing 'const .. uncompressed_size' with 'const .. &uncompressed_size'. content_meta.cpp 62
- V801 Decreased performance. It is better to redefine the fourth function argument as a reference. Consider replacing 'const .. compressed_size' with 'const .. &compressed_size'. content_meta.cpp 63